### PR TITLE
Add license to include-code-files.lua

### DIFF
--- a/_extensions/include-code-files/include-code-files.lua
+++ b/_extensions/include-code-files/include-code-files.lua
@@ -1,3 +1,9 @@
+--- include-code-files.lua – filter to include code from source files
+---
+--- Copyright: © 2020 Bruno BEAUFILS, 2022 Sam Edwardes
+--- License:   MIT – see LICENSE file for details
+
+
 --- Dedent a line
 local function dedent (line, n)
   return line:sub(1,n):gsub(" ","") .. line:sub(n+1)


### PR DESCRIPTION
Added the licnse detail inside of `include-code-files.lua` file.